### PR TITLE
merge jf cleanup with covidstats work

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,6 +27,10 @@
   max-height: 300px;
 }
 
+.keyboard-focused {
+  color: black !important;
+}
+
 .page-footer a:hover {
   text-decoration: underline;
 }

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     <!--Import materialize.css-->
     <link rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
-    <link href="./assets/css/style.css" type="text/css" rel="stylesheet"
-        media="screen,projection" />
+    <link href="./assets/css/style.css" type="text/css" rel="stylesheet" media="screen,projection" />
+
 </head>
 
 <body>
@@ -23,7 +23,6 @@
         <div class="nav-wrapper container">
             <a href="#" class="brand-logo">COVID-19 Tracker</a>
             <ul id="nav-mobile" class="right hide-on-med-and-down">
-                <li><a href="sass.html">Countries</a></li>
                 <li><a href="badges.html">News</a></li>
                 <li><a href="collapsible.html">About Us</a></li>
             </ul>
@@ -170,16 +169,25 @@
                 <div class="col l6 s12">
                     <h5 class="white-text">Team Overview</h5>
                     <p class="grey-text text-lighten-4">
-                        We are a team of students in the Berkeley Software Development Bootcamp. This site leverages HTML, CSS, jQuery, and Materialize.
+                        We are a team of students in the Berkeley Software Development Bootcamp. 
+                        <br><br>
+                        This site leverages HTML, CSS, jQuery, and Materialize.
                     </p>
                 </div>
-                <div class="col l6 s12">
+                <div class="col l6 s12 right-align">
                     <h5 class="white-text">Connect</h5>
                     <ul>
-                        <li><a class="white-text" href="https://www.linkedin.com/in/mike-ebener-6b08557b" target="_blank">Mike Ebener</a></li>
-                        <li><a class="white-text" href="https://www.linkedin.com/in/ben-gerner-790683208" target="_blank">Ben Gerner</a></li>
-                        <li><a class="white-text" href="https://www.linkedin.com/in/obinna-ezeka-000734206" target="_blank">Obinna Ezeka</a></li>
-                        <li><a class="white-text" href="https://www.linkedin.com/in/jefffollestad" target="_blank">Jeff Follestad</a></li>
+                        <li><a class="white-text"
+                            href="https://www.linkedin.com/in/mike-ebener-6b08557b"
+                            target="_blank">Mike Ebener</a></li>
+                    <li><a class="white-text"
+                            href="https://www.linkedin.com/in/ben-gerner-790683208"
+                            target="_blank">Ben Gerner</a></li>
+                    <li><a class="white-text"
+                            href="https://www.linkedin.com/in/obinna-ezeka-000734206"
+                            target="_blank">Obinna Ezeka</a></li>
+                    <li><a class="white-text" href="https://www.linkedin.com/in/jefffollestad"
+                            target="_blank">Jeff Follestad</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
combining the following:

Mike E fixes
- Script updated with functions to call for each data type (confirmed, deaths & recovered) with console logs
- Updated html to have 3 containers for the data to show up in eventually (not particularly pretty)
- Used non-Materialize CSS to style just to show high level what it could look like. Those styles should eventually be deleted and replaced with Materialize

Jeff fixes
- updated materialize styling
- fixed formatting in footer and some general house keeping in html

